### PR TITLE
Run compiled viterbi on external data

### DIFF
--- a/src/levenshtein.mc
+++ b/src/levenshtein.mc
@@ -1,0 +1,35 @@
+include "seq.mc"
+
+let levenshtein = lam s1. lam s2.
+  let n1 = addi (length s1) 1 in
+  let n2 = addi (length s2) 1 in
+  let mat = ref (create n1 (lam i. create n2 (lam i. 0))) in
+  recursive let work = lam row. lam col.
+    let val =
+      if eqi row 0 then col
+      else if eqi col 0 then row
+      else
+        let replace =
+          let v = get (get (deref mat) (subi row 1)) (subi col 1) in
+          if eqc (get s1 (subi row 1)) (get s2 (subi col 1)) then v else addi v 1
+        in
+        let insert = addi (get (get (deref mat) (subi row 1)) col) 1 in
+        let delete = addi (get (get (deref mat) row) (subi col 1)) 1 in
+        minOrElse (lam. error "Empty sequence") subi
+                  [replace, insert, delete]
+    in
+    modref mat (set (deref mat) row (set (get (deref mat) row) col val));
+    if and (eqi row (subi n1 1)) (eqi col (subi n2 1)) then
+      ()
+    else if eqi col (subi n2 1) then
+      work (addi row 1) 0
+    else
+      work row (addi col 1)
+  in
+  work 0 0;
+  get (get (deref mat) (length s1)) (length s2)
+
+utest levenshtein "" "" with 0
+utest levenshtein "massa" "maska" with 1
+utest levenshtein "kitten" "sitting" with 3
+utest levenshtein "ACGT" "GCT" with 2

--- a/src/main.mc
+++ b/src/main.mc
@@ -27,11 +27,6 @@ let eqStates = lam s1. lam s2. eqi (compareStates s1 s2) 0
 
 let log1 = 0.0
 
--- predecssors
--- d = 1 <- d \in {1,2}, any satisfying kmer
--- d = 2 <- d \in {1,3}, any satisfying kmer from 1
--- ...
--- d = D <- d \in {1,D}, any satisfying kmer
 let pred = lam inputs. lam numLayers : Int. lam s : State.
   let layer1 = {s with layer = 1} in
   concat

--- a/src/main.mc
+++ b/src/main.mc
@@ -1,0 +1,77 @@
+include "string.mc"
+include "map.mc"
+
+type State = {
+  kmer : [a],
+  layer : Int
+}
+
+let compareStates = lam s1 : State. lam s2 : State.
+  let cmp = cmpString s1.kmer s2.kmer in
+  if eqi cmp 0 then
+    subi s1.layer s2.layer
+  else cmp
+
+let eqStates = lam s1. lam s2. eqi (compareStates s1 s2) 0
+
+-- predecssors
+-- d = 1 <- d \in {1,2}, any satisfying kmer
+-- d = 2 <- d \in {1,3}, any satisfying kmer from 1
+-- ...
+-- d = D <- d \in {1,D}, any satisfying kmer
+let pred = lam inputs : [a]. lam numLayers : Int. lam s : State.
+  let layer1 = {s with layer = 1} in
+  concat
+    (map (lam i. {layer1 with kmer = cons i (init layer1.kmer)}) inputs)
+    (if eqi s.layer numLayers then
+       [{s with layer = s.layer}]
+     else
+       [{s with layer = addi s.layer 1}])
+
+let _inputs = ['A','C','G','T']
+let _eqPreds = lam s1. lam s2.
+  let s1 = sort compareStates s1 in
+  let s2 = sort compareStates s2 in
+  eqSeq eqStates s1 s2
+
+utest pred _inputs 3 {kmer = ['A','A','A'], layer = 1} with [
+  {kmer = ['A','A','A'], layer = 1},
+  {kmer = ['C','A','A'], layer = 1},
+  {kmer = ['G','A','A'], layer = 1},
+  {kmer = ['T','A','A'], layer = 1},
+  {kmer = ['A','A','A'], layer = 2}
+] using _eqPreds
+utest pred _inputs 3 {kmer = ['A','A','A'], layer = 2} with [
+  {kmer = ['A','A','A'], layer = 1},
+  {kmer = ['C','A','A'], layer = 1},
+  {kmer = ['G','A','A'], layer = 1},
+  {kmer = ['T','A','A'], layer = 1},
+  {kmer = ['A','A','A'], layer = 3}
+] using _eqPreds
+
+recursive let powf = lam b : Float. lam e : Int.
+  if eqi e 0 then 1.0
+  else mulf b (powf b (subi e 1))
+end
+
+let initProbs = lam inputs. lam s : State.
+  if eqi s.layer 1 then
+    divf 1.0 (powf (length inputs) (length s.kmer))
+  else 0.0
+
+let states = lam inputs. lam numLayers.
+  recursive let work = lam n.
+    if eqi n 0 then [[]]
+    else
+      let recTails = work (subi n 1) in
+      join (map (lam tail. map (lam letter. cons letter tail) inputs) recTails)
+  in work numLayers
+
+-- viterbi
+--  compareStates : State -> State -> Int.
+--  predecessors : State -> [State].
+--  transitionProb : State -> State -> LogProb.
+--  initProbs : State -> LogProb.
+--  states : [State].
+--  outputProb : State -> a -> LogProb.
+--  inputs : [a].

--- a/src/main.mc
+++ b/src/main.mc
@@ -11,6 +11,7 @@ include "viterbi.mc"
 -- What are mapped reads?
 -- fakegenome and signals100_1_KTHDNA, should they be equal?
 -- Ending on layer > 1
+-- BLAST score - divide by reference string or produced string?
 
 type State = {
   kmer : [a],
@@ -177,4 +178,7 @@ utest lastState.layer with 1 in
 -- printLn (join ["[\n", strJoin ",\n" (map printState result.states), "]"]);
 printLn (printStates result.states);
 printLn (float2string result.prob);
-printLn (int2string (levenshtein (printStates result.states) reference))
+
+let dist = levenshtein (printStates result.states) reference in
+let blast = subf 1.0 (divf (int2float dist) (int2float (length reference))) in
+printLn (float2string (blast))

--- a/src/main.mc
+++ b/src/main.mc
@@ -1,6 +1,7 @@
-include "string.mc"
+include "levenshtein.mc"
 include "map.mc"
 include "parse.mc"
+include "string.mc"
 include "viterbi.mc"
 
 -- TODO:
@@ -134,6 +135,7 @@ mexpr
 
 let model = parseModel (get argv 1) in
 let signals = parseSignals (get argv 2) in
+let reference = readFile (get argv 3) in
 let bases = "ACGT" in
 let inputSignal : Signal = get signals 0 in
 let baseToIndex = lam base : Char.
@@ -179,4 +181,5 @@ utest lastState.layer with 1 in
 
 -- printLn (join ["[\n", strJoin ",\n" (map printState result.states), "]"]);
 printLn (printStates result.states);
-printLn (float2string result.prob)
+printLn (float2string result.prob);
+printLn (int2string (levenshtein (printStates result.states) reference))

--- a/src/main.mc
+++ b/src/main.mc
@@ -1,5 +1,13 @@
 include "string.mc"
 include "map.mc"
+include "parse.mc"
+include "viterbi.mc"
+
+-- TODO:
+-- kmer to unique index
+-- Always 4 bases?
+-- Initial probabilities?
+-- What are mapped reads?
 
 type State = {
   kmer : [a],
@@ -19,7 +27,7 @@ let eqStates = lam s1. lam s2. eqi (compareStates s1 s2) 0
 -- d = 2 <- d \in {1,3}, any satisfying kmer from 1
 -- ...
 -- d = D <- d \in {1,D}, any satisfying kmer
-let pred = lam inputs : [a]. lam numLayers : Int. lam s : State.
+let pred = lam inputs. lam numLayers : Int. lam s : State.
   let layer1 = {s with layer = 1} in
   concat
     (map (lam i. {layer1 with kmer = cons i (init layer1.kmer)}) inputs)
@@ -28,25 +36,25 @@ let pred = lam inputs : [a]. lam numLayers : Int. lam s : State.
      else
        [{s with layer = addi s.layer 1}])
 
-let _inputs = ['A','C','G','T']
+let _bases = "ACGT"
 let _eqPreds = lam s1. lam s2.
   let s1 = sort compareStates s1 in
   let s2 = sort compareStates s2 in
   eqSeq eqStates s1 s2
 
-utest pred _inputs 3 {kmer = ['A','A','A'], layer = 1} with [
-  {kmer = ['A','A','A'], layer = 1},
-  {kmer = ['C','A','A'], layer = 1},
-  {kmer = ['G','A','A'], layer = 1},
-  {kmer = ['T','A','A'], layer = 1},
-  {kmer = ['A','A','A'], layer = 2}
+utest pred _bases 3 {kmer = "AAA", layer = 1} with [
+  {kmer = "AAA", layer = 1},
+  {kmer = "CAA", layer = 1},
+  {kmer = "GAA", layer = 1},
+  {kmer = "TAA", layer = 1},
+  {kmer = "AAA", layer = 2}
 ] using _eqPreds
-utest pred _inputs 3 {kmer = ['A','A','A'], layer = 2} with [
-  {kmer = ['A','A','A'], layer = 1},
-  {kmer = ['C','A','A'], layer = 1},
-  {kmer = ['G','A','A'], layer = 1},
-  {kmer = ['T','A','A'], layer = 1},
-  {kmer = ['A','A','A'], layer = 3}
+utest pred _bases 3 {kmer = "AAA", layer = 2} with [
+  {kmer = "AAA", layer = 1},
+  {kmer = "CAA", layer = 1},
+  {kmer = "GAA", layer = 1},
+  {kmer = "TAA", layer = 1},
+  {kmer = "AAA", layer = 3}
 ] using _eqPreds
 
 recursive let powf = lam b : Float. lam e : Int.
@@ -54,24 +62,104 @@ recursive let powf = lam b : Float. lam e : Int.
   else mulf b (powf b (subi e 1))
 end
 
-let initProbs = lam inputs. lam s : State.
+let initProbs = lam numInputs. lam s : State.
   if eqi s.layer 1 then
-    divf 1.0 (powf (length inputs) (length s.kmer))
-  else 0.0
+    divf 1.0 (powf (int2float numInputs) (length s.kmer))
+  else negf (divf 1.0 0.0)
 
-let states = lam inputs. lam numLayers.
+let states = lam inputs. lam kmerLength. lam numLayers.
   recursive let work = lam n.
     if eqi n 0 then [[]]
     else
       let recTails = work (subi n 1) in
       join (map (lam tail. map (lam letter. cons letter tail) inputs) recTails)
-  in work numLayers
+  in
+  let kmers = work kmerLength in
+  recursive let work2 = lam n.
+    if eqi n 0 then []
+    else
+      let states = map (lam kmer. {kmer = kmer, layer = n}) kmers in
+      concat states (work2 (subi n 1))
+  in
+  work2 numLayers
 
--- viterbi
---  compareStates : State -> State -> Int.
---  predecessors : State -> [State].
---  transitionProb : State -> State -> LogProb.
---  initProbs : State -> LogProb.
---  states : [State].
---  outputProb : State -> a -> LogProb.
---  inputs : [a].
+utest states _bases 0 1 with [{kmer = [], layer = 1}] using eqSeq eqStates
+utest states "AC" 2 2
+with [{kmer = "AA", layer = 1},
+      {kmer = "CA", layer = 1},
+      {kmer = "AC", layer = 1},
+      {kmer = "CC", layer = 1},
+      {kmer = "AA", layer = 2},
+      {kmer = "CA", layer = 2},
+      {kmer = "AC", layer = 2},
+      {kmer = "CC", layer = 2}]
+using (lam s1. lam s2.
+         let s1 = sort compareStates s1 in
+         let s2 = sort compareStates s2 in
+         eqSeq eqStates s1 s2)
+
+let stateToIndex = lam numInputs. lam baseToIndex : a -> Int. lam s : State.
+  foldl
+    addi
+    0
+    (mapi
+      (lam i. lam k.
+        let factor = floorfi (powf (int2float numInputs) i) in
+        muli (baseToIndex k) factor)
+      s.kmer)
+
+let _bases = "AC"
+let _baseToIndex = lam c.
+  if eqc c 'A' then 0 else if eqc c 'C' then 1 else error (join ["Unknown input: ", [c]])
+utest stateToIndex 2 _baseToIndex {kmer = "AA", layer = 1} with 0
+utest stateToIndex 2 _baseToIndex {kmer = "AA", layer = 2} with 0
+utest stateToIndex 2 _baseToIndex {kmer = "AC", layer = 1} with 2
+utest stateToIndex 2 _baseToIndex {kmer = "CC", layer = 2} with 3
+
+let printState : State -> String = lam s : State.
+  join ["{kmer=", s.kmer, ", layer=", int2string s.layer, "}"]
+
+let printStates = lam states : [State].
+  let layer1states : [State] = filter (lam s : State. eqi s.layer 1) states in
+  if null layer1states then []
+  else match layer1states with [h] ++ t then
+    join [h.kmer, map (lam s : State. last s.kmer) t]
+  else never
+
+mexpr
+
+let model = parseModel (get argv 1) in
+let signals = parseSignals (get argv 2) in
+let bases = "ACGT" in
+let inputSignal : Signal = get signals 0 in
+let baseToIndex = lam input : Char.
+  if eqc input 'A' then 0
+  else if eqc input 'C' then 1
+  else if eqc input 'G' then 2
+  else if eqc input 'T' then 3
+  else error (join ["Invalid input character: ", [input]])
+in
+
+let result : ViterbiResult =
+  viterbi
+    compareStates
+    (pred bases model.dMax)
+    (lam s1 : State. lam s2 : State.
+      let stateIdx = stateToIndex (length bases) baseToIndex s1 in
+      let baseIdx = baseToIndex (last s2.kmer) in
+      get (get model.transitionProbabilities baseIdx) stateIdx)
+    (initProbs (length bases))
+    (states bases model.k model.dMax)
+    -- model.outputProbabilities
+    (lam s : State. lam i : Int.
+      let stateIndex = stateToIndex (length bases) baseToIndex s in
+      get (get model.observationProbabilities i) stateIndex)
+    inputSignal.values
+in
+
+let lastState : State = last result.states in
+utest lastState.layer with 1 in
+
+-- printLn (join ["[\n", strJoin ",\n" (map printState result.states), "]"]);
+printLn (printStates result.states);
+printLn (float2string result.prob)

--- a/src/parse.mc
+++ b/src/parse.mc
@@ -1,0 +1,127 @@
+include "string.mc"
+include "stringid.mc"
+include "mexpr/boot-parser.mc"
+include "mexpr/ast.mc"
+include "mexpr/ast-builder.mc"
+
+type ViterbiParams =
+{ signalLevels : Int
+, observationProbabilities : [[Float]]
+, transitionProbabilities : [[Float]]
+, duration : [Float]
+, k : Int
+, dMax : Int
+, tailFactor : Float
+}
+
+type Signal = {id : String, values : [Int]}
+
+let _expr2int : Expr -> Int = use MExprAst in lam expr.
+  match expr with TmConst {val = CInt {val = i}} then i
+  else dprintLn expr; error "Expected integer"
+
+utest _expr2int (int_ 42) with 42
+
+let _expr2char : Expr -> Char = use MExprAst in lam expr.
+  match expr with TmConst {val = CChar {val = c}} then c
+  else error "Expected character"
+
+utest _expr2char (char_ 'a') with 'a'
+
+let _expr2float : Expr -> Flaot = use MExprAst in lam expr.
+  match expr with TmConst {val = CFloat {val = v}} then v
+  -- negative numbers
+  else match expr with
+    TmApp {lhs = TmConst {val = CNegf _}, rhs = TmConst {val = CFloat {val = v}}}
+  then negf v
+  -- minus infinity
+  else match expr with
+    TmApp {
+      lhs = TmConst {val = CNegf _},
+      rhs = TmApp {lhs = TmApp {lhs = TmConst {val = CDivf _},
+                          rhs = TmConst {val = CFloat {val = v1}}},
+             rhs = TmConst {val = CFloat {val = v2}}}}
+  then negf (divf v1 v2)
+  else dprintLn expr; error "Expected float"
+
+utest _expr2float (float_ 0.20001) with 0.20001 using eqfApprox 1e-6
+
+let _expr2seq : (Expr -> a) -> Expr -> [a] = use MExprAst in lam f. lam expr.
+  match expr with TmSeq {tms = tms} then
+    map f tms
+  else error "Expected sequence"
+
+let _expr2floatSeq : Expr -> [Float] = _expr2seq _expr2float
+
+utest _expr2floatSeq (seq_ [float_ 0.1, float_ 0.43, float_ 78.97123])
+with [0.1, 0.43, 78.97123]
+using eqSeq (eqfApprox 1e-6)
+
+let _expr2floatSeqOfSeq : Expr -> [[Float]] = _expr2seq (_expr2seq _expr2float)
+
+utest _expr2floatSeqOfSeq (seq_ [seq_ [float_ 0.0, float_ 1.01],
+                            seq_ [float_ 0.6, float_ 10.1]])
+with [[0.0, 1.01], [0.6, 10.1]]
+using
+  (lam s1. lam s2. eqSeq (lam e1. lam e2. eqSeq (eqfApprox 1e-6) e1 e2) s1 s2)
+
+let _expr2strSeq : Expr -> [String] = _expr2seq (_expr2seq _expr2char)
+utest _expr2strSeq (seq_ [str_ "Hello", str_ "World"]) with ["Hello", "World"]
+
+let _expr2intSeqOfSeq : Expr -> [[Int]] = _expr2seq (_expr2seq _expr2int)
+utest _expr2intSeqOfSeq (seq_ [seq_ [int_ 1, int_ 2], seq_ [int_ 3]]) with [[1,2],[3]]
+
+let parseModel : String -> ViterbiParams = lam filename.
+  use BootParser in
+  let str = readFile filename in
+  let parsed = parseMExprString [] str in
+
+  match parsed with TmRecord {bindings = bindings} then
+    let bindings = mapBindings bindings in
+    let bindings = map (lam t : (SID, Expr). (sidToString t.0, t.1)) bindings in
+    let bindings : Map String Expr = mapFromList cmpString bindings in
+
+    let signalLevels = _expr2int (mapFindWithExn "signalLevels" bindings) in
+    let observationProbs = _expr2floatSeqOfSeq (mapFindWithExn "observationProbabilities" bindings) in
+    let transitionProbs = _expr2floatSeqOfSeq (mapFindWithExn "transitionProbabilities" bindings) in
+    let duration = _expr2floatSeq (mapFindWithExn "duration" bindings) in
+    let k = _expr2int (mapFindWithExn "k" bindings) in
+    let dMax = _expr2int (mapFindWithExn "dMax" bindings) in
+    let tailFactor = _expr2float (mapFindWithExn "tailFactor" bindings) in
+
+    { signalLevels = signalLevels
+    , observationProbabilities = observationProbs
+    , transitionProbabilities = transitionProbs
+    , duration = duration
+    , k = k
+    , dMax = dMax
+    , tailFactor = tailFactor
+    }
+
+  else error "Expected record"
+
+let parseSignals : String -> [Signal] = lam filename.
+  use BootParser in
+  let str = readFile filename in
+  let parsed = parseMExprString [] str in
+
+  match parsed with TmRecord {bindings = bindings} then
+    let bindings = mapBindings bindings in
+    let bindings = map (lam t : (SID, Expr). (sidToString t.0, t.1)) bindings in
+    let bindings : Map String Expr = mapFromList cmpString bindings in
+
+    let keys = _expr2strSeq (mapFindWithExn "keys" bindings) in
+    let signals = _expr2intSeqOfSeq (mapFindWithExn "signals" bindings) in
+
+    zipWith (lam k. lam s. {id = k, values = s}) keys signals
+
+  else error "Expected record"
+
+mexpr
+dprintLn (
+parseModel (get argv 1)
+);
+
+dprintLn (
+parseSignals (get argv 2)
+)

--- a/src/parse.mc
+++ b/src/parse.mc
@@ -12,6 +12,7 @@ type ViterbiParams =
 , k : Int
 , dMax : Int
 , tailFactor : Float
+, tailFactorComp : Float
 }
 
 type Signal = {id : String, values : [Int]}
@@ -88,6 +89,7 @@ let parseModel : String -> ViterbiParams = lam filename.
     let k = _expr2int (mapFindWithExn "k" bindings) in
     let dMax = _expr2int (mapFindWithExn "dMax" bindings) in
     let tailFactor = _expr2float (mapFindWithExn "tailFactor" bindings) in
+    let tailFactorComp = _expr2float (mapFindWithExn "tailFactorComp" bindings) in
 
     { signalLevels = signalLevels
     , observationProbabilities = observationProbs
@@ -96,6 +98,7 @@ let parseModel : String -> ViterbiParams = lam filename.
     , k = k
     , dMax = dMax
     , tailFactor = tailFactor
+    , tailFactorComp = tailFactorComp
     }
 
   else error "Expected record"

--- a/src/parse.py
+++ b/src/parse.py
@@ -6,15 +6,15 @@ def format_list(lst):
     ret = ",".join(["\"{x}\"".format(x=x) for x in lst])
     return "[" + ret + "]"
 
+def float2str(v):
+    if v == float("-inf"):
+        return "negf (divf 1.0 0.0)"
+    elif v < 0.0:
+        return "negf {}".format(-v)
+    else:
+        "{}".format(v)
 
 def floatList2str(data):
-    def float2str(v):
-        if v == float("-inf"):
-            return "negf (divf 1.0 0.0)"
-        elif v < 0.0:
-            return "negf {}".format(-v)
-        else:
-            return "{}".format(v)
     lst = map(float2str, data)
     s = ",".join(["{x}".format(x=x) for x in lst])
     return "[" + s + "]"
@@ -36,6 +36,7 @@ def read_model(model_path):
         D = f['Tables']['DurationProbabilities'].shape[0]
         tail_factor = f['Tables']['DurationProbabilities'].attrs['TailFactor']
         duration = f['Tables']['DurationProbabilities'][:]
+        # TODO: sum(duration) == 1 ?
         duration[-1] = duration[-1]*(1-tail_factor)
         middlek = int(kmer//2)
 
@@ -44,7 +45,8 @@ def read_model(model_path):
             'transitionProbabilities': floatListOfList2str(np.log(transition).tolist()),
             'k': kmer,
             'dMax': D,
-            'tailFactor': tail_factor,
+            'tailFactor': float2str(np.log(tail_factor)),
+            'tailFactorComp': float2str(np.log(1.0-tail_factor)),
             'duration': floatList2str(np.log(duration).tolist())}
 
 
@@ -58,6 +60,7 @@ def write_model(output_file, model):
         , k = {k}
         , dMax = {dMax}
         , tailFactor = {tailFactor}
+        , tailFactorComp = {tailFactorComp}
         , duration = {duration}
         }}
         """
@@ -67,6 +70,7 @@ def write_model(output_file, model):
                     k=model['k'],
                     dMax=model['dMax'],
                     tailFactor=model['tailFactor'],
+                    tailFactorComp=model['tailFactorComp'],
                     duration=model['duration'])
         )
 

--- a/src/parse.py
+++ b/src/parse.py
@@ -1,0 +1,109 @@
+import numpy as np
+import h5py
+import argparse
+
+def format_list(lst):
+    ret = ",".join(["\"{x}\"".format(x=x) for x in lst])
+    return "[" + ret + "]"
+
+
+def floatList2str(data):
+    def float2str(v):
+        if v == float("-inf"):
+            return "negf (divf 1.0 0.0)"
+        elif v < 0.0:
+            return "negf {}".format(-v)
+        else:
+            return "{}".format(v)
+    lst = map(float2str, data)
+    s = ",".join(["{x}".format(x=x) for x in lst])
+    return "[" + s + "]"
+
+def floatListOfList2str(data):
+    return "[" + ",".join(map(floatList2str, data)) + "]"
+
+
+def read_model(model_path):
+    with h5py.File(model_path, 'r') as f:
+        normal_high = f['Parameters']['Normalization'].attrs['HighClip']
+        normal_low = f['Parameters']['Normalization'].attrs['LowClip']
+        signal_n = f['Parameters']['Normalization'].attrs['SignalLevels']
+        signal_n = f['Tables']['ObservationProbabilities'].shape[0]
+        observation = f['Tables']['ObservationProbabilities'][:]
+        transition = f['Tables']['TransitionProbabilities'][:]
+        kmer = (
+            np.log2(f['Tables']['ObservationProbabilities'].shape[1])/2).astype(int)
+        D = f['Tables']['DurationProbabilities'].shape[0]
+        tail_factor = f['Tables']['DurationProbabilities'].attrs['TailFactor']
+        duration = f['Tables']['DurationProbabilities'][:]
+        duration[-1] = duration[-1]*(1-tail_factor)
+        middlek = int(kmer//2)
+
+    return {'signalLevels': signal_n,
+            'observationProbabilities': floatListOfList2str(np.log(observation).tolist()),
+            'transitionProbabilities': floatListOfList2str(np.log(transition).tolist()),
+            'k': kmer,
+            'dMax': D,
+            'tailFactor': tail_factor,
+            'duration': floatList2str(np.log(duration).tolist())}
+
+
+def write_model(output_file, model):
+    with open(output_file, 'w') as out:
+        out.write(
+            """
+        {{ signalLevels = {signalLevels}
+        , observationProbabilities = {observationProbabilities}
+        , transitionProbabilities = {transitionProbabilities}
+        , k = {k}
+        , dMax = {dMax}
+        , tailFactor = {tailFactor}
+        , duration = {duration}
+        }}
+        """
+            .format(signalLevels=model['signalLevels'],
+                    observationProbabilities=model['observationProbabilities'],
+                    transitionProbabilities=model['transitionProbabilities'],
+                    k=model['k'],
+                    dMax=model['dMax'],
+                    tailFactor=model['tailFactor'],
+                    duration=model['duration'])
+        )
+
+
+def read_signal(signal_path):
+    with h5py.File(signal_path, 'r') as f:
+        keys = list(f.keys())
+        signals = [f[k]['Raw']['Signal'][:].tolist() for k in keys]
+        return {'keys': keys, 'signals': signals}
+
+def write_signal(output_file, signals):
+    with open(output_file, 'w') as out:
+        out.write(
+            """
+            {{ keys = {keys}
+            , signals = {signals}
+            }}
+            """
+            .format(keys=format_list(signals['keys'][0:1]),
+                    signals=signals['signals'][0:1])
+        )
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Convert Trellis fast 5 files into text files.')
+    parser.add_argument(
+        '--model', help='filename of input model in fast 5 format')
+    parser.add_argument('--output-model', help='filename of output model')
+    parser.add_argument(
+        '--signal', help='filename of input signal in fast 5 format')
+    parser.add_argument('--output-signal', help='filename of output signal')
+
+    args = parser.parse_args()
+
+    model = read_model(args.model)
+    write_model(args.output_model, model)
+
+    signals = read_signal(args.signal)
+    write_signal(args.output_signal, signals)

--- a/src/viterbi.mc
+++ b/src/viterbi.mc
@@ -2,6 +2,8 @@ include "common.mc"
 include "math.mc"
 include "string.mc"
 
+type ViterbiResult = {prob : LogProb, states : [State]}
+
 let mapInit : (k -> k -> Int) -> [k] -> (k -> v) -> Map k v = lam compare. lam keys. lam f.
   foldl (lam acc. lam k. mapInsert k (f k) acc) (mapEmpty compare) keys
 
@@ -72,7 +74,6 @@ let viterbi = -- ... -> {states : [State], prob : LogProb}
 
 mexpr
 
-type ViterbiResult = {prob : LogProb, states : [State]} in
 let compareViterbiResult = lam delta. lam l : ViterbiResult. lam r : ViterbiResult.
   match l with {states = lstates, prob = lprob} then
     match r with {states = rstates, prob = rprob} then
@@ -95,9 +96,8 @@ let outputProbs = [
   [('A', negf 1.737), ('C', negf 2.322), ('G', negf 2.322), ('T', negf 1.737)]
 ] in
 let outputProb = lam state. lam v.
-  match find (lam t : (State, LogProb). eqc v t.0) (get outputProbs state) with Some t then
-    let t : (State, LogProb) = t in
-    t.1
+  match find (lam t : (State, LogProb). eqc v t.0) (get outputProbs state) with Some (_, prob) then
+    prob
   else error (join ["No key '", v "' found"])
 in
 let inputs = ['G', 'G', 'C', 'A', 'C', 'T', 'G', 'A', 'A'] in

--- a/src/viterbi.mc
+++ b/src/viterbi.mc
@@ -1,3 +1,4 @@
+include "common.mc"
 include "math.mc"
 include "string.mc"
 
@@ -25,7 +26,7 @@ let headExc : [a] -> a = lam as.
   error "Empty list in headExc"
 
 let mapMaxBy : (a -> LogProb) -> Map k a -> Option k = lam f. lam m.
-  optionMap (lam x. x.0) (maxBy (lam binding. f binding.1) (mapBindings m))
+  optionMap (lam x : (k, a). x.0) (maxBy (lam binding : (k, a). f binding.1) (mapBindings m))
 let mapMaxByExc : (a -> LogProb) -> Map k a -> Option k = lam f. lam m.
   match mapMaxBy f m with Some x then x
   else dprint (mapBindings m); error "Empty map in mapMaxByExc"
@@ -71,7 +72,8 @@ let viterbi = -- ... -> {states : [State], prob : LogProb}
 
 mexpr
 
-let compareViterbiResult = lam delta. lam l. lam r.
+type ViterbiResult = {prob : LogProb, states : [State]} in
+let compareViterbiResult = lam delta. lam l : ViterbiResult. lam r : ViterbiResult.
   match l with {states = lstates, prob = lprob} then
     match r with {states = rstates, prob = rprob} then
       and (all (lam b. b) (zipWith eqi lstates rstates))
@@ -93,7 +95,8 @@ let outputProbs = [
   [('A', negf 1.737), ('C', negf 2.322), ('G', negf 2.322), ('T', negf 1.737)]
 ] in
 let outputProb = lam state. lam v.
-  match find (lam t. eqc v t.0) (get outputProbs state) with Some t then
+  match find (lam t : (State, LogProb). eqc v t.0) (get outputProbs state) with Some t then
+    let t : (State, LogProb) = t in
     t.1
   else error (join ["No key '", v "' found"])
 in
@@ -119,7 +122,8 @@ let outputProbs = [
   [("normal", negf 3.322), ("cold", negf 1.737), ("dizzy", negf 0.737)]
 ] in
 let outputProb = lam state. lam v.
-  match find (lam t. eqString v t.0) (get outputProbs state) with Some t then
+  match find (lam t : (State, LogProb). eqString v t.0) (get outputProbs state) with Some t then
+    let t : (State, LogProb) = t in
     t.1
   else error (join ["No key '", v, "' found"])
 in


### PR DESCRIPTION
Makes `viterbi.mc` and `forward-backward.mc` compile and adds files to run viterbi on external data.

First use a Python3 script to translate the binary data into a textual format (MCore does not support reading binary files yet and it also does not have a logarithm function). It requires `h5py` to run (install using `pip3 install h5py`):
```
python3 parse.py --model ../synthetic_dna/model/Params3_true.h5 --output-model model.txt --signal ../synthetic_dna/data/signals100_1.fast5 --output-signal signal.txt --reference ../synthetic_dna/data/mapped_reads100_1.hdf5  --output-reference reference.txt
```

If MCore has been installed, you can then compile the program using `mi compile main.mc` and run it with `./main model.txt signal.txt reference.txt`. The output contains three lines: the most likely sequence, the logarithmic probability of that sequence and the BLAST score of the produced sequence relative to the reference.

Co-authored-by: Linnea Ingmar <lingmar@kth.se>