### PR TITLE
Initial parser for Trellis

### DIFF
--- a/src/parser/parser.mc
+++ b/src/parser/parser.mc
@@ -1,0 +1,10 @@
+include "trellis.mc"
+
+mexpr
+
+let f = get argv 1 in
+let s = readFile f in
+let res = parseTrellisExn f s in
+
+()
+

--- a/src/parser/test/EDHMM.trellis
+++ b/src/parser/test/EDHMM.trellis
@@ -1,0 +1,45 @@
+# DEFINES EXPLICIT DURATION HMM(EDHMM) - the model we are using now for the DNA basecaller
+
+# TODO: define constants/is "automaton" class or template?
+
+# DNA bases
+type Nucleotide {
+  A, C, G, T,  # Comma-separated list of constructors (final comma is presently mandatory)
+}
+
+# TODO: parameterize automata?
+
+let merlength = 6
+
+# automata representing DNA sequence with 5mer states
+automaton DNA_mer {
+ state: Nucleotide[merlength],
+ intra_transitions: ! { ! [a, as..., ] -> [bs..., b, ] | as = bs, },
+}
+
+# durations of Kmer staying in the pore
+automaton Duration16 {
+ state: 1..16,
+ # initial: all states #TODO: range choices
+ # intra_transitions: { x -> y | y = x + 1 } \u { 16 -> 1 },
+ initial: { 3, 4, },
+ intra_transitions: ! { ! x -> y | true, },
+ inter_transitions: ! { ! 1 -> x | 3 <= x && x <= 4, },
+}
+
+# TODO: define the structure of 'output'/measurement
+
+
+model EDHMM = outer:DNA_5mer(inner:Duration16(foo:Innermost)) {
+ table outputProb(Int, outer.state,): Probability
+
+ table outerTrans(Bool, outer.state, outer.state,): Probability
+
+ P(output | x) = O(output, x.outer) # measurement depends only on Kmer
+ P(initial x) = InitOuter(x.outer) * InitInner(x.inner)
+ P(transition x y) {
+   | inner => InnerTrans(x.inner, y.inner)
+   | outer => OuterTrans(x.outer, y.outer) * InitInner(y.inner)
+ }
+
+}

--- a/src/parser/test/EDHMM.trellis
+++ b/src/parser/test/EDHMM.trellis
@@ -14,7 +14,7 @@ let merlength = 6
 # automata representing DNA sequence with 5mer states
 automaton DNA_mer {
  state: Nucleotide[merlength],
- intra_transitions: ! { [a, as..., ] -> [bs..., b, ] | as = bs, },
+ intra_transitions: @ { [a, as..., ] -> [bs..., b, ] | as = bs, },
 }
 
 # durations of Kmer staying in the pore
@@ -23,8 +23,8 @@ automaton Duration16 {
  # initial: all states #TODO: range choices
  # intra_transitions: { x -> y | y = x + 1 } \u { 16 -> 1 },
  initial: { 3, 4, },
- intra_transitions: ! { x -> y | true, },
- inter_transitions: ! { 1 -> x | 3 <= x && x <= 4, },
+ intra_transitions: @ { x -> y | true, },
+ inter_transitions: @ { 1 -> x | 3 <= x && x <= 4, },
 }
 
 # TODO: define the structure of 'output'/measurement

--- a/src/parser/test/EDHMM.trellis
+++ b/src/parser/test/EDHMM.trellis
@@ -14,7 +14,7 @@ let merlength = 6
 # automata representing DNA sequence with 5mer states
 automaton DNA_mer {
  state: Nucleotide[merlength],
- intra_transitions: ! { ! [a, as..., ] -> [bs..., b, ] | as = bs, },
+ intra_transitions: ! { [a, as..., ] -> [bs..., b, ] | as = bs, },
 }
 
 # durations of Kmer staying in the pore
@@ -23,8 +23,8 @@ automaton Duration16 {
  # initial: all states #TODO: range choices
  # intra_transitions: { x -> y | y = x + 1 } \u { 16 -> 1 },
  initial: { 3, 4, },
- intra_transitions: ! { ! x -> y | true, },
- inter_transitions: ! { ! 1 -> x | 3 <= x && x <= 4, },
+ intra_transitions: ! { x -> y | true, },
+ inter_transitions: ! { 1 -> x | 3 <= x && x <= 4, },
 }
 
 # TODO: define the structure of 'output'/measurement

--- a/src/parser/test/pattern_recognition_example.trellis
+++ b/src/parser/test/pattern_recognition_example.trellis
@@ -1,0 +1,19 @@
+automaton Rtl7 {
+  state: 1 <= x <= 7,
+  transitions: {
+    ! x -> x+1,
+    ! x -> x,
+  },
+  final: {7,},
+  initial: {1,},
+}
+
+model M = r:Rtl7 {
+  # TODO(Linnea,2022-05-11): syntax of probabilities
+  # P(a -> b) = P(a -> b | a.r, b.r)
+  # P(output a) = P(output a | a.r)
+
+  # There is a single initial state so need no
+  # dependencies.
+  P(initial b) = C
+}

--- a/src/parser/test/pattern_recognition_example.trellis
+++ b/src/parser/test/pattern_recognition_example.trellis
@@ -9,7 +9,7 @@ automaton Rtl7 {
 }
 
 model M = r:Rtl7 {
-  # TODO(Linnea,2022-05-11): syntax of probabilities
+  # NOTE(Linnea,2022-05-11): probability syntax deprecated
   # P(a -> b) = P(a -> b | a.r, b.r)
   # P(output a) = P(output a | a.r)
 

--- a/src/parser/test/pattern_recognition_example.trellis
+++ b/src/parser/test/pattern_recognition_example.trellis
@@ -1,8 +1,8 @@
 automaton Rtl7 {
   state: 1 <= x <= 7,
   transitions: {
-    ! x -> x+1,
-    ! x -> x,
+    x -> x+1,
+    x -> x,
   },
   final: {7,},
   initial: {1,},

--- a/src/parser/test/slack-example.trellis
+++ b/src/parser/test/slack-example.trellis
@@ -6,21 +6,21 @@ let merlength = 5
 let maxduration = 16
 
 automaton Thing {
-  state: <Nucleotide[merlength], 1..16>,
-  initial: ! { x | true, },
-  inter: ! { <[a, as...,], 1> -> <[bs..., b,], k> | as = bs, },
-  down: ! { <x, k> -> <x2, k2> | x = x2, k2 = k - 1, },
-  max: ! { <x, n1> -> <x2, n2> | n1 = maxduration, n2 = maxduration, },
-  from_max: ! { <x, n1> -> <x2, n2> | n1 = maxduration, n2 = maxduration - 1, },
+  state: @(Nucleotide[merlength], 1..maxduration),
+  initial: @ { x | true, },
+  inter: @ { @([a, as...,], 1) -> @([bs..., b,], k) | as = bs, },
+  down: @ { @(x, k) -> @(x2, k2) | x = x2, k2 = k - 1, },
+  max: @ { @(x, n1) -> @(x2, n2) | n1 = maxduration, n2 = maxduration, },
+  from_max: @ { @(x, n1) -> @(x2, n2) | n1 = maxduration, n2 = maxduration - 1, },
   transitions: inter \u down \u max,
 }
 
 model M = s:Thing {
   table outputProb(Nucleotide[merlength], 1..1024,): Probability
-  table initialProb(Nucleotide[merlength], 1..16,): Probability
+  table initialProb(Nucleotide[merlength], 1..maxduration,): Probability
 
   table trans1(Nucleotide[merlength], Nucleotide[merlength],): Probability
-  table trans2(1..16,): Probability
+  table trans2(1..maxduration,): Probability
   table gamma(): Probability
 
   P(output | x) = outputProb(x.0, output)

--- a/src/parser/test/slack-example.trellis
+++ b/src/parser/test/slack-example.trellis
@@ -1,0 +1,34 @@
+type Nucleotide {
+  A, C, G, T,  # Comma-separated list of constructors (final comma is presently mandatory)
+}
+
+let merlength = 5
+let maxduration = 16
+
+automaton Thing {
+  state: <Nucleotide[merlength], 1..16>,
+  initial: ! { x | true, },
+  inter: ! { <[a, as...,], 1> -> <[bs..., b,], k> | as = bs, },
+  down: ! { <x, k> -> <x2, k2> | x = x2, k2 = k - 1, },
+  max: ! { <x, n1> -> <x2, n2> | n1 = maxduration, n2 = maxduration, },
+  from_max: ! { <x, n1> -> <x2, n2> | n1 = maxduration, n2 = maxduration - 1, },
+  transitions: inter \u down \u max,
+}
+
+model M = s:Thing {
+  table outputProb(Nucleotide[merlength], 1..1024,): Probability
+  table initialProb(Nucleotide[merlength], 1..16,): Probability
+
+  table trans1(Nucleotide[merlength], Nucleotide[merlength],): Probability
+  table trans2(1..16,): Probability
+  table gamma(): Probability
+
+  P(output | x) = outputProb(x.0, output)
+  P(initial x) = initialProb(x.0, x.1)
+  P(transition x y) {
+    | s.inter => trans1(x.0, y.0) * trans2(y.1)
+    | s.max => gamma
+    | s.from_max => 1 - gamma
+    | s.down \setminus s.from_max => 1
+  }
+}

--- a/src/parser/test/test.trellis
+++ b/src/parser/test/test.trellis
@@ -1,0 +1,92 @@
+type Base {
+  A, T, C, G,
+}
+
+type Option(a){
+  Some(a), None,
+}
+
+automaton Nucleo5mer {
+  state: (Option(Base))[5],
+  transitions: {
+    ! [a, b, c, d, e, ] -> [b, c, d, e, Some(f),],
+  },
+  initial: {
+    [None, None, None, None, Some(x),],
+  },
+}
+
+automaton Duration {
+  state: 1 <= x <= 5,
+  transitions: {
+    ! x -> x-1,  # We silently discard edges connecting to invalid states
+    ! x+1 -> x,  # This is equivalent with the above (*)
+    ! 5 -> 5,    # If we don't use variables we get a single edge
+  },
+# initial defaults to all, i.e., "initial: {x},"
+# final is optional
+  final: {1,},
+}
+
+# (*) I'm not entirely sure if we want to do
+# this, we might want to limit the lhs to
+# simple patterns, but all this depends on how
+# we discover which states are actually reachable
+# and part of the automaton and whatnot.
+
+automaton Machine {
+  state: 1 <= x <= 4,
+  initial: {1,},
+  transitions: {
+    ! x -> x+1,
+    ! x -> x,
+    ! x -> x-1,
+  },
+  final: {4,},
+}
+
+# TODO(Linnea,2022-05-11): syntax of probabilities
+# # The right-hand side (before "{") describes
+# # the composition of automata that makes up
+# # the topology of the model.
+# # In this case we have an outer automaton
+# # (Nucleo5mer) and an inner (Duration). The
+# # inner model must have final states, which
+# # are the only states from which we can transition
+# # to a new state in the outer model.
+# model M = n:Nucleo5mer(d:Duration) {
+
+#   # This states that the output distribution of
+#   # a state depends on all available data
+#   P(output a) = P(output a | a.n, a.d)
+#   # Underscore means "repeat the thing we're
+#   # defining", in this case P(_ | a.n) is the
+#   # same as P(a -> b | a.n)
+
+#   P(output a) = P(_ | a.n, a.d)
+
+#   # This states that the probability of starting
+#   # in a given state depends on all data, but
+#   # with a bit less freedom; the probability
+#   # must be the product of starting in the given
+#   # base sequence and starting in the given
+#   # duration, which in context means that the
+#   # duration a given base will stay does not
+#   # depend on which base it is.
+#   P(initial b) = P(_ | b.n) * P(_ | b.d)
+
+#   # The transition probability has different
+#   # dependencies depending on if we're
+#   # transitioning inside a base sequence or
+#   # to a new one.
+#   P(a -> b) {
+#     | a.n == b.n = P(_ | a.n, a.d, b.d)
+#     | otherwise = P(_ | a.n, b.n) * P(initial b | b.d)
+#   }
+# }
+
+# The result of the dependencies here is primarily
+# how much data we must store; we only need
+# |Nucleo5mer|^2 + |Duration| numbers for
+# transitions instead of the complete
+# |Nucleo5mer|^2 * |Duration|.

--- a/src/parser/test/test.trellis
+++ b/src/parser/test/test.trellis
@@ -9,7 +9,7 @@ type Option(a){
 automaton Nucleo5mer {
   state: (Option(Base))[5],
   transitions: {
-    ! [a, b, c, d, e, ] -> [b, c, d, e, Some(f),],
+    [a, b, c, d, e, ] -> [b, c, d, e, Some(f),],
   },
   initial: {
     [None, None, None, None, Some(x),],
@@ -19,9 +19,9 @@ automaton Nucleo5mer {
 automaton Duration {
   state: 1 <= x <= 5,
   transitions: {
-    ! x -> x-1,  # We silently discard edges connecting to invalid states
-    ! x+1 -> x,  # This is equivalent with the above (*)
-    ! 5 -> 5,    # If we don't use variables we get a single edge
+    x -> x-1,  # We silently discard edges connecting to invalid states
+    x+1 -> x,  # This is equivalent with the above (*)
+    5 -> 5,    # If we don't use variables we get a single edge
   },
 # initial defaults to all, i.e., "initial: {x},"
 # final is optional
@@ -38,9 +38,9 @@ automaton Machine {
   state: 1 <= x <= 4,
   initial: {1,},
   transitions: {
-    ! x -> x+1,
-    ! x -> x,
-    ! x -> x-1,
+    x -> x+1,
+    x -> x,
+    x -> x-1,
   },
   final: {4,},
 }

--- a/src/parser/test/test.trellis
+++ b/src/parser/test/test.trellis
@@ -45,7 +45,7 @@ automaton Machine {
   final: {4,},
 }
 
-# TODO(Linnea,2022-05-11): syntax of probabilities
+# NOTE(Linnea,2022-05-11): probability syntax deprecated
 # # The right-hand side (before "{") describes
 # # the composition of automata that makes up
 # # the topology of the model.

--- a/src/parser/test/tutorial.trellis
+++ b/src/parser/test/tutorial.trellis
@@ -43,7 +43,7 @@ automaton ExampleAutomaton {
   # commas), integers (using ranges), fix length arrays (using
   # "T[n]"), user defined types (by name, applied to any needed
   # arguments)
-  state: <Example, 1..10, Option(Bool)[3]>,
+  state: @(Example, 1..10, Option(Bool)[3]),
 
   # Unbound identifiers (e.g. a, b, c, x, and y below) are implicitly
   # universally quantified in "initial", "final", and
@@ -62,7 +62,10 @@ automaton ExampleAutomaton {
   transitions: {
     @(A, x, y) -> @(B, x, y),
     @(B, x, y) -> @(B, x+1, y),
-    ! name: @(C, x, y) -> @(C, x, y),
+    # ! name: @(C, x, y) -> @(C, x, y),
+    @(C, x, y) -> @(C, x, y),
+    # NOTE(Linnea,2022-05-16): labelling syntax deprecated, as transitions
+    # can be constructed as union of individual named sets.
   },
   # Transitions may additionally be labelled. This has no semantic
   # effect, but may be used for querying the model later. Note that if
@@ -75,7 +78,7 @@ automaton ExampleAutomaton {
 # various probabilities may depend on. Note that this does not assign
 # probabilities, merely what they may be conditional on.
 
-# TODO(Linnea,2022-05-11): syntax of probabilities
+# NOTE(Linnea,2022-05-11): probability syntax deprecated
 # # On the right-hand side of the "=" is the
 # # composition. "name:Automaton" specifies that "Automaton" is a part
 # # of the composition, and gives access to its state through
@@ -138,7 +141,7 @@ automaton Machine {
   },
 }
 
-# TODO(Linnea,2022-05-11): syntax of probabilities
+# NOTE(Linnea,2022-05-11): probability syntax deprecated
 # model M = outer:Nucleo3mer(inner:Machine) {
 #   P(output x) = P(_ | x.outer, classify(x.inner))
 #   P(initial x) = P(_ | x.outer, x.inner)

--- a/src/parser/test/tutorial.trellis
+++ b/src/parser/test/tutorial.trellis
@@ -35,7 +35,7 @@ automaton Trivial {
   final: { true, },
 
   # This declares the valid transitions.
-  transitions: { ! false -> true, },
+  transitions: { false -> true, },
 }
 
 automaton ExampleAutomaton {
@@ -50,19 +50,19 @@ automaton ExampleAutomaton {
   # "transitions". Can specify multiple expressions by separating them
   # with commas
   initial: {
-    @<A, 1, [Some(a), Some(b), Some(c),]>@,
-    @<B, x, y>@,
+    @(A, 1, [Some(a), Some(b), Some(c),]),
+    @(B, x, y),
   },
 
   final: {
-    @<A, 1, x>@,
-    @<B, 2, y>@,
+    @(A, 1, x),
+    @(B, 2, y),
   },
 
   transitions: {
-    ! @<A, x, y>@ -> @<B, x, y>@,
-    ! @<B, x, y>@ -> @<B, x+1, y>@,
-    ! :name: @<C, x, y>@ -> @<C, x, y>@,
+    @(A, x, y) -> @(B, x, y),
+    @(B, x, y) -> @(B, x+1, y),
+    ! name: @(C, x, y) -> @(C, x, y),
   },
   # Transitions may additionally be labelled. This has no semantic
   # effect, but may be used for querying the model later. Note that if
@@ -111,7 +111,7 @@ automaton ExampleAutomaton {
 automaton Nucleo3mer {
   state: Nucleotide[3],
   transitions: {
-    ! [a, b, c, ] -> [b, c, d, ],
+    [a, b, c, ] -> [b, c, d, ],
   },
 }
 
@@ -132,9 +132,9 @@ automaton Machine {
   initial: { 1, },
   final: { 4, },
   transitions: {
-    ! x -> x,
-    ! x -> x+1,
-    ! x -> x-1,
+    x -> x,
+    x -> x+1,
+    x -> x-1,
   },
 }
 

--- a/src/parser/test/tutorial.trellis
+++ b/src/parser/test/tutorial.trellis
@@ -1,0 +1,163 @@
+# Comments with #
+
+# Type declarations (algebraic data types) with "type"
+type Example {
+  A, B, C,  # Comma-separated list of constructors (final comma is presently mandatory)
+}
+# Supports an arbitrary number of type parameters
+type Option(a) {
+  Some(a), None,
+}
+
+# All types must be finite, since they generate states, which must be finite
+
+# A type declaration may not be recursive
+# type Rec {
+#   Rec
+# }
+
+# The first step to describing a model is creating one or more
+# automata, to describe the topology of the model.
+
+# Automata are declared using "automaton". These are non-deterministic
+# finite automata, with or without final states.
+automaton Trivial {
+
+  # This declares the type of states in this automaton. Mandatory.
+  state: Bool,
+
+  # This declares which states the automaton may start in. Defaults to
+  # all states.
+  initial: { false, },
+
+  # This declares which states are final, i.e., from which states we
+  # may transition out of this automaton. Defaults to no states.
+  final: { true, },
+
+  # This declares the valid transitions.
+  transitions: { ! false -> true, },
+}
+
+automaton ExampleAutomaton {
+  # Supported types include tuples (using "(,,,)", with any number of
+  # commas), integers (using ranges), fix length arrays (using
+  # "T[n]"), user defined types (by name, applied to any needed
+  # arguments)
+  state: <Example, 1..10, Option(Bool)[3]>,
+
+  # Unbound identifiers (e.g. a, b, c, x, and y below) are implicitly
+  # universally quantified in "initial", "final", and
+  # "transitions". Can specify multiple expressions by separating them
+  # with commas
+  initial: {
+    @<A, 1, [Some(a), Some(b), Some(c),]>@,
+    @<B, x, y>@,
+  },
+
+  final: {
+    @<A, 1, x>@,
+    @<B, 2, y>@,
+  },
+
+  transitions: {
+    ! @<A, x, y>@ -> @<B, x, y>@,
+    ! @<B, x, y>@ -> @<B, x+1, y>@,
+    ! :name: @<C, x, y>@ -> @<C, x, y>@,
+  },
+  # Transitions may additionally be labelled. This has no semantic
+  # effect, but may be used for querying the model later. Note that if
+  # two transition expressions overlap (e.g., "fromTrue: true -> a"
+  # and "toTrue: a -> true"), and both are labelled, then edges
+  # introduced by both (e.g. "true -> true") have both labels.
+}
+
+# The next step is to compose the automata and declare what the
+# various probabilities may depend on. Note that this does not assign
+# probabilities, merely what they may be conditional on.
+
+# TODO(Linnea,2022-05-11): syntax of probabilities
+# # On the right-hand side of the "=" is the
+# # composition. "name:Automaton" specifies that "Automaton" is a part
+# # of the composition, and gives access to its state through
+# # "name". "x(y)" specifies that each state of the automaton "x"
+# # contains a copy of the automaton "y". Note that "y" has to have
+# # final states, otherwise the outer automaton will never transition.
+# model M = blub:Trivial(foo:Trivial) {
+
+#   # This specifies that the probability of starting in a state "x" is
+#   # dependent on both "x.outer" and "x.inner", i.e., it depends on all
+#   # available state.
+#   P(initial x) = P(initial x | x.outer, x.inner)
+#   # Note however that P(initial x) cannot be greater than 0 unless
+#   # both x.outer and x.inner are initial in their respective automaton
+
+#   # This specifies that the output distribution of state "x" is only
+#   # dependent on "x.outer", i.e., the number of output distributions
+#   # we need to store is cut in half, since "Trivial" has two states.
+#   P(output x) = P(output x | x.outer)
+
+#   # It is also possible to specify multiple equations, each guarded by
+#   # a condition. The first condition that holds true is the one that
+#   # will be used.
+#   P(a -> b) = {
+#     | a.outer == b.outer => P(a -> b | a.outer, a.inner, b.inner)
+#     | a.outer /= b.outer => P(_ | a.outer, b.outer) * P(initial b | b.inner)
+#   }
+#   # It is also possible to use "P(_ | ...)" as shorthand for the
+#   # probability we're currently defining, i.e., above "P(_ | a.outer,
+#   # b.outer)" is syntactic sugar for "P(a -> b | a.outer, b.outer)".
+# }
+
+automaton Nucleo3mer {
+  state: Nucleotide[3],
+  transitions: {
+    ! [a, b, c, ] -> [b, c, d, ],
+  },
+}
+
+# We can also declare values. Note that the type is mandatory
+let otherwise: Bool = true
+
+# If we add arguments we get a function. Note that the function should
+# be total, it must terminate without exception on all inputs. Most of
+# the time this shouldn't matter since most functions will be simple,
+# but if we allow recursive functions we might run into trouble.
+let add (a : 1..4, b : 1..4): 2..8 = a + b
+
+let classify (x : 1..4): 1..2 =
+  if x == 1 || x == 2 then 1 else 2
+
+automaton Machine {
+  state: 1..4,
+  initial: { 1, },
+  final: { 4, },
+  transitions: {
+    ! x -> x,
+    ! x -> x+1,
+    ! x -> x-1,
+  },
+}
+
+# TODO(Linnea,2022-05-11): syntax of probabilities
+# model M = outer:Nucleo3mer(inner:Machine) {
+#   P(output x) = P(_ | x.outer, classify(x.inner))
+#   P(initial x) = P(_ | x.outer, x.inner)
+#   P(a -> b) = {
+#     | a.outer == b.outer => P(_ | a.outer, a.inner, b.inner)
+#     | otherwise => P(_ | a.outer, b.outer) * P(initial b | b.inner)
+#   }
+# }
+
+# model M = outer:Nucleo3mer(inner:Machine*4) {
+#   P(output x) = P(_ | x.outer, classify(x.inner))
+#   P(initial x) = P(_ | x.outer, x.inner)
+#   P(a -> b) = {
+#     | a.outer == b.outer => P(_ | a.outer, a.inner, b.inner)
+#     | otherwise => P(_ | a.outer, b.outer) * P(initial b | b.inner)
+#   }
+# }
+
+# # TODO: function calls with parentheses (also for type-level stuff)
+# # TODO: function declarations
+# # TODO: probabilities conditional on expressions
+# # TODO: fast-stepping inner automata

--- a/src/parser/trellis-lexer.mc
+++ b/src/parser/trellis-lexer.mc
@@ -1,0 +1,60 @@
+include "parser/lexer.mc"
+
+lang TrellisSetTokenParser = TokenParser
+  syn Token =
+  | SetUnionTok {info : Info}
+  | SetIntersectionTok {info : Info}
+  | SetInTok {info : Info}
+  | SetNotinTok {info : Info}
+  syn TokenRepr =
+  | SetUnionRepr ()
+  | SetIntersectionRepr ()
+  | SetInRepr ()
+  | SetNotinRepr ()
+
+  sem parseToken (pos : Pos) =
+  | "\\u" ++ str ->
+    let pos2 = advanceCol pos 3 in
+    let info = makeInfo pos pos2 in
+    {token = SetUnionTok {info = info}, lit = "\\u", info = info, stream = {pos = pos2, str = str}}
+  | "\\n" ++ str ->
+    let pos2 = advanceCol pos 3 in
+    let info = makeInfo pos pos2 in
+    {token = SetIntersectionTok {info = info}, lit = "\\n", info = info, stream = {pos = pos2, str = str}}
+  | "\\in" ++ str ->
+    let pos2 = advanceCol pos 4 in
+    let info = makeInfo pos pos2 in
+    {token = SetInTok {info = info}, lit = "\\in", info = info, stream = {pos = pos2, str = str}}
+  | "\\notin" ++ str ->
+    let pos2 = advanceCol pos 7 in
+    let info = makeInfo pos pos2 in
+    {token = SetNotinTok {info = info}, lit = "\\notin", info = info, stream = {pos = pos2, str = str}}
+
+end
+
+-- Eat line comments of the form #
+lang TrellisLineCommentParser = WSACParser
+  sem eatWSAC (p : Pos)  =
+  | "#" ++ xs ->
+    recursive
+    let remove = lam p. lam str.
+      match str with "\n" ++ xs then eatWSAC (advanceRow p 1) xs else
+      match str with [x] ++ xs then remove (advanceCol p 1) xs else
+      eatWSAC p str
+    in remove p xs
+end
+
+-- Eat line comments of the form #
+lang TrellisDotsTokenParser = TokenParser
+  syn Token =
+  | DotsToken {info : Info}
+  syn TokenRepr =
+  | DotsRepr ()
+
+  sem parseToken (pos : Pos) =
+  | "..." ++ str ->
+    let pos2 = advanceCol pos 3 in
+    let info = makeInfo pos pos2 in
+    {token = DotsToken {info = info}, lit = "...", info = info, stream = {pos = pos2, str = str}}
+
+end

--- a/src/parser/trellis-lexer.mc
+++ b/src/parser/trellis-lexer.mc
@@ -4,11 +4,13 @@ lang TrellisSetTokenParser = TokenParser
   syn Token =
   | SetUnionTok {info : Info}
   | SetIntersectionTok {info : Info}
+  | SetMinusTok {info : Info}
   | SetInTok {info : Info}
   | SetNotinTok {info : Info}
   syn TokenRepr =
   | SetUnionRepr ()
   | SetIntersectionRepr ()
+  | SetMinusRepr ()
   | SetInRepr ()
   | SetNotinRepr ()
 
@@ -29,6 +31,10 @@ lang TrellisSetTokenParser = TokenParser
     let pos2 = advanceCol pos 7 in
     let info = makeInfo pos pos2 in
     {token = SetNotinTok {info = info}, lit = "\\notin", info = info, stream = {pos = pos2, str = str}}
+  | "\\setminus" ++ str ->
+    let pos2 = advanceCol pos 10 in
+    let info = makeInfo pos pos2 in
+    {token = SetMinusTok {info = info}, lit = "\\setminus", info = info, stream = {pos = pos2, str = str}}
 
 end
 

--- a/src/parser/trellis.syn
+++ b/src/parser/trellis.syn
@@ -130,7 +130,7 @@ prod NamedSet: TrellisSet = name:LIdent
 -- a value set or a transition set, and give an error if mixed.
 -- Example (value set): {1, a}
 -- Example (transition set): { ! false -> true,  }
--- TODO: syntax for transition set
+-- TODO: syntax for transition set and labelled transitions
 prod SetLit: TrellisSet =
   "{"
     ((e:Expr | "!" (":" lbl:LIdent ":")? e:Expr "->" to:Expr) ",")*
@@ -193,7 +193,7 @@ type Type {
 
 -- Defines a type application
 postfix TypeApplication: Type =
-  "(" a:Type ("," a2:Type)* ")"
+  "(" a:Type ("," a:Type)* ")"
 
 -- Defines an array type
 postfix ArrayType: Type = "[" count:Expr "]"
@@ -229,7 +229,7 @@ type Expr {
 
 -- Operators
 postfix Application: Expr =
-  "(" (a:Expr ("," a2:Expr)*)? ")"
+  "(" (a:Expr ("," a:Expr)*)? ")"
 infix left Plus: Expr = "+"
 infix left Minus: Expr = "-"
 infix left MultipliedWith: Expr = "*"
@@ -314,7 +314,7 @@ type InModelDecl
 prod InferredFunction: InModelDecl =
   "table" f:LIdent
   "("
-    (p2:Type ",")*
+    (p:Type ",")*
   ")" (":" ret:Type)?
 
 -- The rhs using '=>' is only valid for transition probability

--- a/src/parser/trellis.syn
+++ b/src/parser/trellis.syn
@@ -1,23 +1,24 @@
 language Trellis
 
+include "trellis-lexer.mc"
+
 ------------
 -- Tokens --
 ------------
 
+-- Basic tokens
 token LIdent {
   repr = LIdentRepr {},
   constructor = LIdentTok,
   fragment = LIdentTokenParser,
   ty = String,
 }
-
 token UIdent {
   repr = UIdentRepr {},
   constructor = UIdentTok,
   fragment = UIdentTokenParser,
   ty = String,
 }
-
 token Integer {
   repr = IntRepr {},
   constructor = IntTok,
@@ -25,6 +26,7 @@ token Integer {
   ty = Int,
 }
 
+-- Wrapping tokens that just change the type in the AST
 token UName {
   base = UIdent,
   wrap = nameNoSym,
@@ -35,6 +37,17 @@ token LName {
   wrap = nameNoSym,
   ty = Name,
 }
+
+-- Token types only used through literals
+token {fragment = OperatorTokenParser,}
+token {fragment = CommaTokenParser,}
+token {fragment = BracketTokenParser,}
+token {fragment = TrellisSetTokenParser,}
+token {fragment = TrellisDotsTokenParser,}
+
+-- Whitespace and comments
+token {fragment = TrellisLineCommentParser,}
+token {fragment = WhitespaceParser,}
 
 ----------------------------
 -- Top-level declarations --
@@ -48,7 +61,7 @@ type ConstrDecl
 type AutomatonProp
 type Param
 
-prod Top: Top = d:Decl+
+prod Top: Top = d:Decl*
 
 -- Defines a constructor declaration production.
 -- Examples: 'Foo (foo, bar)', 'A'
@@ -93,46 +106,46 @@ prod StateProp: AutomatonProp =
   "state" ":" ty:Type
 
 prod SetProp: AutomatonProp =
-  (name:LIdent | initial:"initial") ":" s:Set
+  (name:LIdent | initial:"initial") ":" s:TrellisSet
 
 ----------
 -- Sets --
 ----------
 
-type Set {
+type TrellisSet {
   grouping = "(" ")",
 }
 
 -- Defines an infix set union operator
-infix left SetUnion: Set = "\\u"
+infix left SetUnion: TrellisSet = "\\u"
 
 -- Defines an infix set intersection operator
-infix left SetIntersection: Set = "\\n"
+infix left SetIntersection: TrellisSet = "\\n"
 
 -- Defines a named set.
 -- Example: 'mySet'
-prod NamedSet: Set = name:LIdent
+prod NamedSet: TrellisSet = name:LIdent
 
 -- Defines a set literal. A later pass over the AST needs to check whether it is
 -- a value set or a transition set, and give an error if mixed.
 -- Example (value set): {1, a}
--- Example (transition set): { @ false -> true,  }
+-- Example (transition set): { ! false -> true,  }
 -- TODO: syntax for transition set
-prod SetLit: Set =
+prod SetLit: TrellisSet =
   "{"
-    ((e:Expr | "@" e:Expr "->" to:Expr) ",")*
+    ((e:Expr | "!" (":" lbl:LIdent ":")? e:Expr "->" to:Expr) ",")*
   "}"
 
 -- Defines a set builder. A later pass over the AST needs to check whether it is
 -- a value set or a transition set builder.
--- Example (transition set builder): {{ @ x -> y | true }}
--- TODO: syntax for tr
-prod SetBuilder: Set =
-  "{{"
-     (p:Pat | "@" p:Pat "->" to:Pat)
+-- Example (transition set builder): !{ @ x -> y | true }
+-- TODO: syntax for transitions
+prod SetBuilder: TrellisSet =
+  "!" "{"
+     (p:Pat | "!" p:Pat "->" to:Pat)
      "|"
      (e:Expr ",")*
-   "}}"
+   "}"
 
 --------------
 -- Patterns --
@@ -152,20 +165,18 @@ prod VarPat: Pat = id:LIdent
 prod WildPat: Pat = "_"
 
 -- Only allowed in an ArrayPat
--- TODO: why does it trigger an LL1 conflict for Con?
--- postfix DotsPat: Pat = p:Pat "..."
+postfix DotsPat: Pat = "..."
 
 prod ArrayPat: Pat =
   "[" (p:Pat ",")* "]"
 
 -- Defines a tuple pattern
 -- Example '(foo, [a])'
--- TODO: syntax not ideal
+-- TODO: tuple syntax
 prod TupPat: Pat =
   "<" p:Pat ("," p:Pat)+ ">"
 
 -- Defines an integer pattern
--- TODO: negative integers?
 prod IntPat: Pat = i:Integer
 
 -- Defines Boolean patterns
@@ -196,7 +207,14 @@ prod TupleType: Type = "<" t:Type ("," t:Type)+ ">"
 
 -- Defines an integer type
 prod IntegerType: Type =
-  lb:Integer (".." ub:Integer)?
+  --lb:Integer (".." ub:Integer)?
+  lb:Integer ((".." ub:Integer) | ("<=" v:LIdent "<=" ub:Integer))?
+
+-- Defines a Boolean type
+prod BoolType: Type = bool:"Bool"
+
+-- Defines an integer type
+prod IntType: Type = int:"Int"
 
 -- Defines an automaton state type
 prod AutomatonState: Type = automaton:LIdent "." "state"
@@ -217,7 +235,7 @@ infix left Minus: Expr = "-"
 infix left MultipliedWith: Expr = "*"
 infix left DividedBy: Expr = "/"
 -- Either a nested access or a tuple access
-postfix ProjectionAccess: Expr = "." (label:LIdent | index:Integer)
+postfix ProjectionAccess: Expr = "." (label:LIdent | count:Integer)
 infix Equal: Expr = ("=" | "==")
 infix NotEqual: Expr = ("/=" | "!=")
 infix LessThan: Expr = "<"
@@ -241,8 +259,7 @@ prod Variable: Expr = v:LName
 prod Constructor: Expr = c:UName
 prod Integer: Expr = i:Integer
 -- May only be used inside a List
--- TODO: LL1 conflict
--- prod SubSeq: Expr = s:LIdent "..."
+postfix SubSeq: Expr = "..."
 prod List: Expr = "[" (e:Expr ",")* "]"
 -- TODO: tuple syntax
 prod Tuple: Expr =
@@ -273,15 +290,11 @@ precedence {
 -- MODEL DEFINITION --
 ----------------------
 
-type ModelDecl
 prod ModelDecl: Decl =
   "model" name:UIdent "=" mc:ModelComposition
   "{"
-    (indecl:InModelDecl ",")+
+    (indecl:InModelDecl)+
   "}"
-
--- Below is copied from the syncon file, I don't entirely remember the intended
--- semantics behind all of these.
 
 type ModelComposition {
   grouping = "(" ")",
@@ -301,14 +314,14 @@ type InModelDecl
 prod InferredFunction: InModelDecl =
   "table" f:LIdent
   "("
-    ("," p2:Type ",")*
+    (p2:Type ",")*
   ")" (":" ret:Type)?
 
--- The latter rhs only valid for transition probability
+-- The rhs using '=>' is only valid for transition probability
 prod Prob: InModelDecl =
   "P" "("
-    ( output:"output"
-    | initial:"initital"
+    ( output:"output" "|" s:LIdent
+    | initial:"initial" s:LIdent
     | transition:"transition" from:LIdent to:LIdent) ")"
     ( "=" e:Expr
     | /- "="? -- TODO: ll1 -/ "{"

--- a/src/parser/trellis.syn
+++ b/src/parser/trellis.syn
@@ -133,17 +133,16 @@ prod NamedSet: TrellisSet = name:LIdent
 -- a value set or a transition set, and give an error if mixed.
 -- Example (value set): {1, a, }
 -- Example (transition set): { false -> true,  }
--- TODO: syntax for labeled transitions
 prod SetLit: TrellisSet =
   "{"
-    (("!" lbl:LIdent ":")? e:Expr ("->" to:Expr)? ",")*
+    (e:Expr ("->" to:Expr)? ",")*
   "}"
 
 -- Defines a set builder. A later pass over the AST needs to check whether it is
 -- a value set or a transition set builder.
--- Example (transition set builder): !{ x -> y | true }
+-- Example (transition set builder): @{ x -> y | true }
 prod SetBuilder: TrellisSet =
-  "!" "{"
+  "@" "{"
      (p:Pat ("->" to:Pat)?)
      "|"
      (e:Expr ",")*
@@ -183,9 +182,8 @@ prod ArrayPat: Pat =
 
 -- Defines a tuple pattern
 -- Example '(foo, [a])'
--- TODO: tuple syntax
 prod TupPat: Pat =
-  "<" p:Pat ("," p:Pat)+ ">"
+  "@" "(" p:Pat ("," p:Pat)+ ")"
 
 -- Defines an integer pattern
 prod IntPat: Pat = i:Integer
@@ -213,13 +211,11 @@ postfix ArrayType: Type = "[" count:Expr "]"
 prod ConcreteType: Type = n:UIdent
 
 -- Defines a tuple type
--- TODO: tuple syntax
-prod TupleType: Type = "<" t:Type ("," t:Type)+ ">"
+prod TupleType: Type = "@" "(" t:Type ("," t:Type)+ ")"
 
 -- Defines an integer range type
 prod IntegerType: Type =
-  --lb:Integer (".." ub:Integer)?
-  lb:Integer ((".." ub:Integer) | ("<=" v:LIdent "<=" ub:Integer))?
+  lb:Integer ((".." (ub:Integer | namedUb:LIdent)) | ("<=" v:LIdent "<=" ub:Integer))?
 
 -- Defines a Boolean type
 prod BoolType: Type = bool:"Bool"
@@ -273,7 +269,6 @@ prod Integer: Expr = i:Integer
 -- May only be used inside a List
 postfix SubSeq: Expr = "..."
 prod List: Expr = "[" (e:Expr ",")* "]"
--- TODO: tuple syntax
 prod Tuple: Expr =
   "@" "(" e:Expr ("," e:Expr)+ ")"
 
@@ -316,10 +311,11 @@ prod ModelAtom: ModelComposition =
   name:LIdent ":" automaton:UIdent
 postfix ModelNesting: ModelComposition =
   "(" mc:ModelComposition ")"
-prod FastStepAutomatonPre: ModelComposition =
-  n:Integer "*"
-postfix FastStepAutomatonPost: ModelComposition =
-  "*" n:Integer
+-- TODO(Linnea,2022-05-16): deprecated?
+-- prod FastStepAutomatonPre: ModelComposition =
+--   n:Integer "*"
+-- postfix FastStepAutomatonPost: ModelComposition =
+--   "*" n:Integer
 
 type InModelDecl
 
@@ -336,7 +332,7 @@ prod Prob: InModelDecl =
     | initial:"initial" s:LIdent
     | transition:"transition" from:LIdent to:LIdent) ")"
     ( "=" e:Expr
-    | /- "="? -- TODO: ll1 -/ "{"
+    | /- "="? -- TODO(Linnea,2022-05-16): ll1 conflict -/ "{"
       ("|" set:TrellisSet "=>" e2:Expr)+
       "}"
     )

--- a/src/parser/trellis.syn
+++ b/src/parser/trellis.syn
@@ -122,30 +122,41 @@ infix left SetUnion: TrellisSet = "\\u"
 -- Defines an infix set intersection operator
 infix left SetIntersection: TrellisSet = "\\n"
 
+-- Defines an infix set minus operator
+infix left TrellisSetMinus: TrellisSet = "\\setminus"
+
 -- Defines a named set.
 -- Example: 'mySet'
 prod NamedSet: TrellisSet = name:LIdent
 
 -- Defines a set literal. A later pass over the AST needs to check whether it is
 -- a value set or a transition set, and give an error if mixed.
--- Example (value set): {1, a}
--- Example (transition set): { ! false -> true,  }
--- TODO: syntax for transition set and labelled transitions
+-- Example (value set): {1, a, }
+-- Example (transition set): { false -> true,  }
+-- TODO: syntax for labeled transitions
 prod SetLit: TrellisSet =
   "{"
-    ((e:Expr | "!" (":" lbl:LIdent ":")? e:Expr "->" to:Expr) ",")*
+    (("!" lbl:LIdent ":")? e:Expr ("->" to:Expr)? ",")*
   "}"
 
 -- Defines a set builder. A later pass over the AST needs to check whether it is
 -- a value set or a transition set builder.
--- Example (transition set builder): !{ @ x -> y | true }
--- TODO: syntax for transitions
+-- Example (transition set builder): !{ x -> y | true }
 prod SetBuilder: TrellisSet =
   "!" "{"
-     (p:Pat | "!" p:Pat "->" to:Pat)
+     (p:Pat ("->" to:Pat)?)
      "|"
      (e:Expr ",")*
    "}"
+
+
+-- Projection
+postfix SetProjection: TrellisSet = "." lbl:LIdent
+
+precedence {
+  SetProjection;
+  ~ SetUnion SetIntersection TrellisSetMinus;
+}
 
 --------------
 -- Patterns --
@@ -205,7 +216,7 @@ prod ConcreteType: Type = n:UIdent
 -- TODO: tuple syntax
 prod TupleType: Type = "<" t:Type ("," t:Type)+ ">"
 
--- Defines an integer type
+-- Defines an integer range type
 prod IntegerType: Type =
   --lb:Integer (".." ub:Integer)?
   lb:Integer ((".." ub:Integer) | ("<=" v:LIdent "<=" ub:Integer))?
@@ -251,6 +262,7 @@ infix In: Expr = "\\in"
 infix Notin: Expr = "\\notin"
 infix left Union: Expr = "\\u"
 infix left Intersection: Expr = "\\n"
+infix left SetMinus: Expr = "\\setminus"
 
 prod Output: Expr = "output"
 prod True: Expr = "true"
@@ -263,7 +275,7 @@ postfix SubSeq: Expr = "..."
 prod List: Expr = "[" (e:Expr ",")* "]"
 -- TODO: tuple syntax
 prod Tuple: Expr =
-  "@<" e:Expr ("," e:Expr)+ ">@"
+  "@" "(" e:Expr ("," e:Expr)+ ")"
 
 precedence {
   ProjectionAccess ArrayAccess Application;
@@ -279,7 +291,7 @@ precedence {
 
 precedence {
   ~ ProjectionAccess ArrayAccess Application;
-  Union;
+  ~ Union Intersection SetMinus;
   In Notin;
   ~ If And Or;
 } except {
@@ -325,6 +337,6 @@ prod Prob: InModelDecl =
     | transition:"transition" from:LIdent to:LIdent) ")"
     ( "=" e:Expr
     | /- "="? -- TODO: ll1 -/ "{"
-      ("|" automaton:LIdent "=>" e2:Expr)+
+      ("|" set:TrellisSet "=>" e2:Expr)+
       "}"
     )

--- a/src/parser/trellis.syn
+++ b/src/parser/trellis.syn
@@ -1,0 +1,317 @@
+language Trellis
+
+------------
+-- Tokens --
+------------
+
+token LIdent {
+  repr = LIdentRepr {},
+  constructor = LIdentTok,
+  fragment = LIdentTokenParser,
+  ty = String,
+}
+
+token UIdent {
+  repr = UIdentRepr {},
+  constructor = UIdentTok,
+  fragment = UIdentTokenParser,
+  ty = String,
+}
+
+token Integer {
+  repr = IntRepr {},
+  constructor = IntTok,
+  fragment = UIntTokenParser,
+  ty = Int,
+}
+
+token UName {
+  base = UIdent,
+  wrap = nameNoSym,
+  ty = Name,
+}
+token LName {
+  base = LIdent,
+  wrap = nameNoSym,
+  ty = Name,
+}
+
+----------------------------
+-- Top-level declarations --
+----------------------------
+
+start Top
+
+type Top
+type Decl
+type ConstrDecl
+type AutomatonProp
+type Param
+
+prod Top: Top = d:Decl+
+
+-- Defines a constructor declaration production.
+-- Examples: 'Foo (foo, bar)', 'A'
+-- Counter example: 'A ()'
+prod ConstrDecl: ConstrDecl =
+  vName:UIdent ("(" param:LIdent ("," param:LIdent)* ")")?
+
+-- Defines a type declaration production.
+-- Example: 'type MyType (foo, bar) {Foo (foo, bar), A, }'
+prod TypeDecl : Decl =
+  "type" name:UIdent ("(" param:LIdent ("," param:LIdent)* ")")?
+  "{"
+    (v:ConstrDecl ",")*
+  "}"
+
+-- Defines an automaton declaration
+-- Example: 'automaton MyAutomaton {_, }'
+prod AutomatonDecl: Decl =
+  "automaton" name:UIdent
+  "{"
+    (prop:AutomatonProp ",")*
+  "}"
+
+-- Defines a parameter
+-- Example: 'foo : _'
+prod Param: Param = n:LIdent ":" ty:Type
+
+-- Defines a function declaration.
+-- Example: 'let myFun(foo:_) : _ = _'
+prod FuncDecl: Decl =
+  "let" fname:LIdent
+  ("(" p:Param ("," p:Param)* ")")?
+  (":" ty:Type)?
+  "=" e:Expr
+
+----------------------------
+-- Properties in automata --
+----------------------------
+
+-- Defines a state property.
+prod StateProp: AutomatonProp =
+  "state" ":" ty:Type
+
+prod SetProp: AutomatonProp =
+  (name:LIdent | initial:"initial") ":" s:Set
+
+----------
+-- Sets --
+----------
+
+type Set {
+  grouping = "(" ")",
+}
+
+-- Defines an infix set union operator
+infix left SetUnion: Set = "\\u"
+
+-- Defines an infix set intersection operator
+infix left SetIntersection: Set = "\\n"
+
+-- Defines a named set.
+-- Example: 'mySet'
+prod NamedSet: Set = name:LIdent
+
+-- Defines a set literal. A later pass over the AST needs to check whether it is
+-- a value set or a transition set, and give an error if mixed.
+-- Example (value set): {1, a}
+-- Example (transition set): { @ false -> true,  }
+-- TODO: syntax for transition set
+prod SetLit: Set =
+  "{"
+    ((e:Expr | "@" e:Expr "->" to:Expr) ",")*
+  "}"
+
+-- Defines a set builder. A later pass over the AST needs to check whether it is
+-- a value set or a transition set builder.
+-- Example (transition set builder): {{ @ x -> y | true }}
+-- TODO: syntax for tr
+prod SetBuilder: Set =
+  "{{"
+     (p:Pat | "@" p:Pat "->" to:Pat)
+     "|"
+     (e:Expr ",")*
+   "}}"
+
+--------------
+-- Patterns --
+--------------
+
+type Pat {
+  grouping = "(" ")",
+}
+
+prod ConPat: Pat = con:UIdent ("(" (p:Pat ",")+ ")")?
+
+-- Defines a named pattern variable
+-- Example: 'foo'
+prod VarPat: Pat = id:LIdent
+
+-- Defines a wildcard pattern
+prod WildPat: Pat = "_"
+
+-- Only allowed in an ArrayPat
+-- TODO: why does it trigger an LL1 conflict for Con?
+-- postfix DotsPat: Pat = p:Pat "..."
+
+prod ArrayPat: Pat =
+  "[" (p:Pat ",")* "]"
+
+-- Defines a tuple pattern
+-- Example '(foo, [a])'
+-- TODO: syntax not ideal
+prod TupPat: Pat =
+  "<" p:Pat ("," p:Pat)+ ">"
+
+-- Defines an integer pattern
+-- TODO: negative integers?
+prod IntPat: Pat = i:Integer
+
+-- Defines Boolean patterns
+prod TruePat: Pat = "true"
+prod FalsePat: Pat = "false"
+
+-----------------------
+-- Normal data types --
+-----------------------
+
+type Type {
+  grouping = "(" ")",
+}
+
+-- Defines a type application
+postfix TypeApplication: Type =
+  "(" a:Type ("," a2:Type)* ")"
+
+-- Defines an array type
+postfix ArrayType: Type = "[" count:Expr "]"
+
+-- Defines a concrete type
+prod ConcreteType: Type = n:UIdent
+
+-- Defines a tuple type
+-- TODO: tuple syntax
+prod TupleType: Type = "<" t:Type ("," t:Type)+ ">"
+
+-- Defines an integer type
+prod IntegerType: Type =
+  lb:Integer (".." ub:Integer)?
+
+-- Defines an automaton state type
+prod AutomatonState: Type = automaton:LIdent "." "state"
+
+-----------------
+-- Expressions --
+-----------------
+
+type Expr {
+  grouping = "(" ")",
+}
+
+-- Operators
+postfix Application: Expr =
+  "(" (a:Expr ("," a2:Expr)*)? ")"
+infix left Plus: Expr = "+"
+infix left Minus: Expr = "-"
+infix left MultipliedWith: Expr = "*"
+infix left DividedBy: Expr = "/"
+-- Either a nested access or a tuple access
+postfix ProjectionAccess: Expr = "." (label:LIdent | index:Integer)
+infix Equal: Expr = ("=" | "==")
+infix NotEqual: Expr = ("/=" | "!=")
+infix LessThan: Expr = "<"
+infix GreaterThan: Expr = ">"
+infix LessThanOrEqual: Expr = "<="
+infix GreaterThanOrEqual: Expr = ">="
+infix left And: Expr = "&&"
+infix left Or: Expr = "||"
+postfix ArrayAccess: Expr = "[" e:Expr "]"
+prefix If: Expr =
+  "if" c:Expr "then" e:Expr "else"
+infix In: Expr = "\\in"
+infix Notin: Expr = "\\notin"
+infix left Union: Expr = "\\u"
+infix left Intersection: Expr = "\\n"
+
+prod Output: Expr = "output"
+prod True: Expr = "true"
+prod False: Expr = "false"
+prod Variable: Expr = v:LName
+prod Constructor: Expr = c:UName
+prod Integer: Expr = i:Integer
+-- May only be used inside a List
+-- TODO: LL1 conflict
+-- prod SubSeq: Expr = s:LIdent "..."
+prod List: Expr = "[" (e:Expr ",")* "]"
+-- TODO: tuple syntax
+prod Tuple: Expr =
+  "@<" e:Expr ("," e:Expr)+ ">@"
+
+precedence {
+  ProjectionAccess ArrayAccess Application;
+  MultipliedWith DividedBy;
+  Plus Minus;
+  ~ Equal NotEqual LessThan GreaterThan LessThanOrEqual GreaterThanOrEqual;
+  And Or;
+  If;
+} except {
+  MultipliedWith ? DividedBy;
+  And ? Or;
+}
+
+precedence {
+  ~ ProjectionAccess ArrayAccess Application;
+  Union;
+  In Notin;
+  ~ If And Or;
+} except {
+  ProjectionAccess ArrayAccess Application ? If And Or;
+}
+
+----------------------
+-- MODEL DEFINITION --
+----------------------
+
+type ModelDecl
+prod ModelDecl: Decl =
+  "model" name:UIdent "=" mc:ModelComposition
+  "{"
+    (in:InModelDecl ",")+
+  "}"
+
+-- Below is copied from the syncon file, I don't entirely remember the intended
+-- semantics behind all of these.
+
+type ModelComposition {
+  grouping = "(" ")",
+}
+
+prod ModelAtom: ModelComposition =
+  name:LIdent ":" automaton:UIdent
+postfix ModelNesting: ModelComposition =
+  "(" mc:ModelComposition ")"
+prod FastStepAutomatonPre: ModelComposition =
+  n:Integer "*"
+postfix FastStepAutomatonPost: ModelComposition =
+  "*" n:Integer
+
+type InModelDecl
+
+prod InferredFunction: InModelDecl =
+  "table" f:LIdent
+  "("
+    ("," p2:Type ",")*
+  ")" (":" ret:Type)?
+
+-- The latter rhs only valid for transition probability
+prod Prob: InModelDecl =
+  "P" "("
+    ( output:"output"
+    | initial:"initital"
+    | transition:"transition" from:LIdent to:LIdent) ")"
+    ( "=" e:Expr
+    | /- "="? -- TODO: ll1 -/ "{"
+      ("|" automaton:LIdent "=>" e2:Expr)+
+      "}"
+    )

--- a/src/parser/trellis.syn
+++ b/src/parser/trellis.syn
@@ -142,7 +142,7 @@ type Pat {
   grouping = "(" ")",
 }
 
-prod ConPat: Pat = con:UIdent ("(" (p:Pat ",")+ ")")?
+prod ConPat: Pat = c:UIdent ("(" (p:Pat ",")+ ")")?
 
 -- Defines a named pattern variable
 -- Example: 'foo'
@@ -277,7 +277,7 @@ type ModelDecl
 prod ModelDecl: Decl =
   "model" name:UIdent "=" mc:ModelComposition
   "{"
-    (in:InModelDecl ",")+
+    (indecl:InModelDecl ",")+
   "}"
 
 -- Below is copied from the syncon file, I don't entirely remember the intended


### PR DESCRIPTION
* Adds an initial version of a parser for Trellis. Only the `.syn` file is included at the moment, not the generated AST + parser.
* Currently adapts the original syntax slightly to avoid LL1 conflicts, I believe this is limited to:
  - tuples must be marked with `@`: `@ (1,2)`
  - final commas are mandatory e.g. in sets and lists: `{1,2,}`
  - set builders must be marked with `@`: `@ { x | true, }`
* Includes parseable example Trellis programs in `src/parser/test` folder.
