### PR TITLE
Update plot scripts to make matplotlib use different fonts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Lars Hummelgren
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/benchmarks/scripts/plot-compile.py
+++ b/benchmarks/scripts/plot-compile.py
@@ -8,6 +8,9 @@ import json
 from colors import colors
 from names import display_name
 
+mpl.rcParams['pdf.fonttype'] = 42
+mpl.rcParams['ps.fonttype'] = 42
+
 def label_file(label, target):
     return f"out/{target}-{label}-compile.json"
 

--- a/benchmarks/scripts/plot-kmer.py
+++ b/benchmarks/scripts/plot-kmer.py
@@ -8,6 +8,9 @@ import json
 from colors import colors
 from names import display_name
 
+mpl.rcParams['pdf.fonttype'] = 42
+mpl.rcParams['ps.fonttype'] = 42
+
 def load_full_time_label(label, conf, k):
     try:
         with open(f"out/{label}-{k}mer-{conf}.json", "r") as f:

--- a/benchmarks/scripts/plot-synthetic.py
+++ b/benchmarks/scripts/plot-synthetic.py
@@ -8,6 +8,9 @@ import json
 from colors import colors
 from names import display_name
 
+mpl.rcParams['pdf.fonttype'] = 42
+mpl.rcParams['ps.fonttype'] = 42
+
 def load_alg_exec_time_label(label, alg, k):
     try:
         with open(f"out/{label}-synthetic-{k}-{alg}.txt", "r") as f:

--- a/benchmarks/scripts/plot-weather.py
+++ b/benchmarks/scripts/plot-weather.py
@@ -8,6 +8,9 @@ import json
 from colors import colors
 from names import display_name
 
+mpl.rcParams['pdf.fonttype'] = 42
+mpl.rcParams['ps.fonttype'] = 42
+
 def load_full_time_label(label, alg):
     try:
         with open(f"out/{label}-weather-{alg}.json", "r") as f:


### PR DESCRIPTION
Fixes the scripts generating plots by having them generate fonts accepted by the paper submission site.
EDIT: The PR now also includes the addition of an MIT license.